### PR TITLE
Expose Python 3 instance attribute annotations where available.

### DIFF
--- a/marrow/schema/declarative.py
+++ b/marrow/schema/declarative.py
@@ -111,11 +111,11 @@ class DataAttribute(Element):
 	the containing object's ``__data__`` dictionary.  If an attempt is made to read an attribute that does not have a
 	corresponding value in the data dictionary an ``AttributeError`` will be raised.
 	
-	Python type annotations relating to the value read/written on instances may be declared as the `annotation`. This
-	will be used to populate the class `__annotations__` for any class an instance of this is assigned to.
+	Python type annotations relating to the value read/written on instances may be declared as the `__annotation__`.
+	This will be used to populate the class `__annotations__` for any class an instance of this is assigned to.
 	"""
 	
-	annotation = None
+	__annotation__ = None
 	
 	def __get__(self, obj, cls=None):
 		"""Executed when retrieving a DataAttribute instance attribute."""

--- a/marrow/schema/meta.py
+++ b/marrow/schema/meta.py
@@ -10,7 +10,7 @@ class ElementMeta(type):
 	"""Instantiation order tracking and attribute naming / collection metaclass.
 	
 	To use, construct subclasses of the Element class whose attributes are themselves instances of Element subclasses.
-	Five attributes on your subclass have magical properties:
+	A number of attributes on your subclass have magical properties:
 	
 	* `inst.__sequence__`
 	  An atomically incrementing (for the life of the process) counter used to preserve order.  Each instance of an
@@ -34,6 +34,9 @@ class ElementMeta(type):
 	  If an instance of your Element subclass is assigned as a property to an Element subclass, this method of your
 	  class will be called to notify you and allow you to make additional adjustments to the class using your subclass.
 	  Should be a classmethod.
+	
+	* `cls.__annotation__`
+	  The Python 3 type annotation to utilize as the "instance attribute type" for this element.
 	
 	Generally you will want to use one of the helper classes provided (Container, Attribute, etc.) however this can be
 	useful if you only require extremely light-weight attribute features on custom objects.
@@ -89,8 +92,8 @@ class ElementMeta(type):
 		ann = attrs.setdefault('__annotations__', dict())
 		
 		for k, v in attributes.items():
-			if not hasattr(v, 'annotation'): continue  # Skip missing or None annotations.
-			ann.setdefault(k, v.annotation)  # If an annotation is already set (explicitly by the developer), skip.
+			if not hasattr(v, '__annotation__'): continue  # Skip missing or None annotations.
+			ann.setdefault(k, v.__annotation__)  # If an annotation is already set (explicitly by the developer), skip.
 		
 		# Construct the new class.
 		cls = type.__new__(meta, str(name), bases, attrs)

--- a/marrow/schema/release.py
+++ b/marrow/schema/release.py
@@ -3,7 +3,7 @@
 from collections import namedtuple
 
 
-version_info = namedtuple('version_info', ('major', 'minor', 'micro', 'releaselevel', 'serial'))(2, 0, 0, 'final', 0)
+version_info = namedtuple('version_info', ('major', 'minor', 'micro', 'releaselevel', 'serial'))(2, 1, 0, 'final', 0)
 version = ".".join([str(i) for i in version_info[:3]]) + ((version_info.releaselevel[0] + str(version_info.serial)) if version_info.releaselevel != 'final' else '')
 
 author = namedtuple('Author', ['name', 'email'])("Alice Bevan-McGregor", 'alice@gothcandy.com')


### PR DESCRIPTION
Migrating to Python 3 as the base for the Marrow ecosystem and embracing all of the _glorious_ modern Python 3.7+ features such as type annotations, Marrow Schema Container objects represent a problem.  One does not want this:

```python
# Imports **purely** for type annotation.  >_<

from typing import Union

from bson import ObjectId as OID
from collections.abc import MutableMapping
from datetime import datetime, timedelta

# Actual imports.

from marrow.mongo import Document
from marrow.mongo.field import ObjectId


class Foo(Document):
	id: Union[OID,datetime,timedelta,MutableMapping,str,bytes] = ObjectId()
```

Having users of Marrow Mongo's ObjectId field type be forced to declare such a Union is absurd. Especially while we wait for [PEP 563](https://www.python.org/dev/peps/pep-0563/) to become more broadly adopted.  (/ wait for Python 4.0).  In the Marrow Mongo case, each field type should absolutely be concretely aware of the instance attribute getter/setter type; the metaclass just needs to aggregate and populate the Container.__annotations__ appropriately.